### PR TITLE
Implement IteratorSize and Base.IteratorEltype

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -134,6 +134,9 @@ function Base.iterate(L::List, xs::List=L)
   first(xs), tail(xs)
 end
 
+Base.IteratorSize(::Type{<:List}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:List}) = Base.EltypeUnknown()
+
 ###########
 # Printing
 ###########


### PR DESCRIPTION
For instance zip should now work with Lazy Lists, because
Base.IteratorSize and Base.IteratorEltype were not implemented this
would lead to StackOverflow when using zip and one of the iterator was a
Lazy List